### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"
@@ -156,7 +155,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5 to 3.9. Check
+3. The pull request should work for Python 3.8 to 3.10. Check
    https://app.travis-ci.com/github/mberz/pyrato/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.8 to 3.10. Check
+3. The pull request should work for Python versions 3.8 or later. Check
    https://app.travis-ci.com/github/mberz/pyrato/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Use pip to install pyrato
 
     $ pip install pyrato
 
-(Requires Python >= 3.5)
+(Requires Python >= 3.8)
 
 
 Getting Started

--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,5 @@ setup(
     url='https://github.com/mberz/pyrato',
     version='0.3.1',
     zip_safe=False,
+    python_requires='>=3.8'
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Remove Python 3.7 support, since it's no longer supported by pyfar and causes incompatibilities with recent numpy versions.