### PR TITLE
Refactor: Use pyfar function to estimate start of an IR.

### DIFF
--- a/pyrato/dsp.py
+++ b/pyrato/dsp.py
@@ -89,43 +89,7 @@ def find_impulse_response_start(
         "Use pyfar.dsp.find_impulse_response_start instead",
         DeprecationWarning)
 
-    ir_squared = np.abs(impulse_response.time)**2
-
-    mask_start = int(0.9*impulse_response.n_samples)
-
-    mask = np.arange(mask_start, ir_squared.shape[-1])
-    noise = np.mean(np.take(ir_squared, mask, axis=-1), axis=-1)
-
-    max_sample = np.argmax(ir_squared, axis=-1)
-    max_value = np.max(ir_squared, axis=-1)
-
-    if np.any(max_value < 10**(threshold/10) * noise) or \
-            np.any(max_sample > mask_start):
-        warnings.warn(
-            "The SNR seems lower than the specified threshold value. Check "
-            "if this is a valid impulse response with sufficient SNR.")
-
-    start_sample = max_sample.copy()
-
-    for ch in np.ndindex(impulse_response.cshape):
-        # Only look for the start sample if the maximum index is bigger than 0
-        if start_sample[ch] > 0:
-            # Check samples before maximum
-            ir_before_max = np.squeeze(
-                ir_squared[ch][:max_sample[ch]+1] / max_value[ch])
-            # First sample above or at the threshold level
-            idx_first_above_thresh = np.where(
-                ir_before_max >= 10**(-threshold/10))[0]
-            if idx_first_above_thresh.size > 0:
-                # The start sample is the last sample below the threshold
-                start_sample[ch] = np.min(idx_first_above_thresh) - 1
-            else:
-                start_sample[ch] = 0
-                warnings.warn(
-                    f'No values below threshold found found for channel {ch}',
-                    'defaulting to 0')
-
-    return np.squeeze(start_sample)
+    return pf.dsp.find_impulse_response_start(impulse_response, threshold)
 
 
 def find_impulse_response_maximum(

--- a/pyrato/dsp.py
+++ b/pyrato/dsp.py
@@ -131,8 +131,9 @@ def find_impulse_response_maximum(
 
     if np.any(max_value < 10**(threshold/10) * noise) or \
             np.any(max_sample > mask_start):
-        raise ValueError("The SNR is lower than the defined threshold. Check \
-                if this is a valid impulse response with sufficient SNR.")
+        warnings.warn(
+            "The SNR seems lower than the specified threshold value. Check "
+            "if this is a valid impulse response with sufficient SNR.")
 
     return np.squeeze(max_sample)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ scipy>=1.5.0
 matplotlib
 autodocsumm
 insipid-sphinx-theme
-pyfar>=0.3.0
+pyfar>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'pyfar>=0.3.0',
+    'pyfar>=0.5.0',
     'numpy>=1.14.0',
     'scipy>=1.5.0',
     'matplotlib']

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -158,6 +158,10 @@ def test_max_ir():
     start_sample_est = dsp.find_impulse_response_maximum(ir_awgn)
     assert start_sample_est == start_sample
 
+    with pytest.warns(match='SNR seems lower'):
+        start_sample_est = dsp.find_impulse_response_maximum(
+            ir_awgn, threshold=200)
+
 # ------------------
 # Time shift
 # ------------------


### PR DESCRIPTION
As of pyfar 0.5.0 the estimation of the starting sample of an IR function is moved to the pyfar.dsp submodule.
The pyrato version we deprecated with pyrato 0.4.0 and removed in pyrato 0.5.0.