### PR TITLE
Add dynamic range threshold for EDCs

### DIFF
--- a/examples/energy_decay_curves_and_reverberation_time.ipynb
+++ b/examples/energy_decay_curves_and_reverberation_time.ipynb
@@ -509,7 +509,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.9.12 ('pyrato')",
    "language": "python",
    "name": "python3"
   },
@@ -524,6 +524,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "af8819fd7f8a66ab9d7215237632d6e1478b14f767e5cd6cf228e02c2933a175"
+   }
   }
  },
  "nbformat": 4,

--- a/pyrato/dsp.py
+++ b/pyrato/dsp.py
@@ -495,3 +495,34 @@ def preprocess_rir(
     energy_data = pf.TimeData(energy_data, times)
 
     return energy_data
+
+
+def peak_signal_to_noise_ratio(
+        impulse_response,
+        noise_power='auto',
+        is_energy=False):
+    """Calculate the peak-signal-to-noise-ratio of an impulse response.
+
+    Parameters
+    ----------
+    impulse_response : pyfar.Signal
+        The impulse response
+    noise_power : float, str, optional
+        The noise power. The default is 'auto', in which case the noise power
+        is estimated from the last 10 % of the impulse response.
+
+    Returns
+    -------
+    float, array-like
+        The estimated peak-signal-to-noise-ratio for each channel of the
+        impulse response.
+
+    """
+    data = impulse_response.time
+    if is_energy is False:
+        data = data**2
+
+    if noise_power == 'auto':
+        noise_power = _estimate_noise_energy(data)
+
+    return np.max(data, axis=-1) / noise_power

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -264,6 +264,21 @@ def test_noise_energy_2D():
     npt.assert_allclose(actual, expected)
 
 
+def test_psnr():
+    n_samples = 2**20
+    peak_levels = np.array([0, -6, -10])
+    noise_level = np.array([-20, -30, -40])
+    imp = pf.signals.impulse(n_samples, amplitude=10**(peak_levels/20))
+    awgn = pf.signals.noise(n_samples, rms=10**(noise_level/20), seed=7)
+    psnr = dsp.peak_signal_to_noise_ratio(imp+awgn)
+
+    npt.assert_allclose(
+        1/psnr, 10**((peak_levels + noise_level)/10), rtol=1e-2, atol=1e-2)
+
+# ----------------
+# RIR preprocessing
+# ----------------
+
 def test_preprocessing_1D():
     rir = genfromtxt(
         os.path.join(test_data_path, 'analytic_rir_psnr50_1D.csv'),

--- a/tests/test_edc_noise_handling.py
+++ b/tests/test_edc_noise_handling.py
@@ -206,18 +206,33 @@ def test_edc_chu_1D(monkeypatch):
         os.path.join(test_data_path, 'edc_chu_1D.csv'),
         delimiter=','))
 
-    # monkeypatch.setattr(
-    #     dsp,
-    #     "find_impulse_response_start",
-    #     mock_shift_samples_1d)
-
     actual = enh.energy_decay_curve_chu(
         rir,
         is_energy=False,
         time_shift=True,
         channel_independent=False,
         normalize=True,
+        threshold=None,
         plot=False)
+    npt.assert_allclose(actual.time, expected)
+
+    # Test with a sufficiently high threshold to ensure exact matching of nans
+    threshold = 15
+    actual = enh.energy_decay_curve_chu(
+        rir,
+        is_energy=False,
+        time_shift=True,
+        channel_independent=False,
+        normalize=True,
+        threshold=threshold,
+        plot=False)
+
+    mask = expected <= 10**((-40+threshold)/10)
+    expected[mask] = np.nan
+
+    pf.plot.time(actual, dB=True, log_prefix=10)
+
+    pf.plot.time(pf.TimeData(expected, actual.times), dB=True, log_prefix=10)
     npt.assert_allclose(actual.time, expected)
 
 
@@ -240,6 +255,7 @@ def test_edc_chu_2D(monkeypatch):
         time_shift=True,
         channel_independent=False,
         normalize=True,
+        threshold=None,
         plot=False)
     npt.assert_allclose(actual.time, expected)
 

--- a/tests/test_edc_noise_handling.py
+++ b/tests/test_edc_noise_handling.py
@@ -45,7 +45,7 @@ def test_substracted_2D():
     npt.assert_allclose(actual, expected)
 
 
-def test_edc_truncation_1D(monkeypatch):
+def test_edc_truncation_1D():
     rir = pf.Signal(genfromtxt(
         os.path.join(test_data_path, 'analytic_rir_psnr50_1D.csv'),
         delimiter=','), 3000)
@@ -53,10 +53,18 @@ def test_edc_truncation_1D(monkeypatch):
         os.path.join(test_data_path, 'edc_truncation_1D.csv'),
         delimiter=','))
 
-    # monkeypatch.setattr(
-    #     dsp,
-    #     "find_impulse_response_start",
-    #     mock_shift_samples_1d)
+    actual = enh.energy_decay_curve_truncation(
+        rir,
+        freq='broadband',
+        is_energy=False,
+        time_shift=True,
+        channel_independent=False,
+        normalize=True,
+        threshold=-np.inf)
+
+    pf.plot.time(actual, dB=True, log_prefix=10)
+
+    npt.assert_allclose(actual.time, expected)
 
     actual = enh.energy_decay_curve_truncation(
         rir,
@@ -64,7 +72,14 @@ def test_edc_truncation_1D(monkeypatch):
         is_energy=False,
         time_shift=True,
         channel_independent=False,
-        normalize=True)
+        normalize=True,
+        threshold=15)
+
+    mask = expected < 10**((-40+15)/10)
+    expected[mask] = np.nan
+
+    pf.plot.time(actual, dB=True, log_prefix=10)
+
     npt.assert_allclose(actual.time, expected)
 
 
@@ -76,18 +91,14 @@ def test_edc_truncation_2D(monkeypatch):
         os.path.join(test_data_path, 'edc_truncation_2D.csv'),
         delimiter=','))
 
-    # monkeypatch.setattr(
-    #     dsp,
-    #     "find_impulse_response_start",
-    #     mock_shift_samples_2d)
-
     actual = enh.energy_decay_curve_truncation(
         rir,
         freq='broadband',
         is_energy=False,
         time_shift=True,
         channel_independent=False,
-        normalize=True)
+        normalize=True,
+        threshold=-np.inf)
     npt.assert_allclose(actual.time, expected)
 
 
@@ -277,3 +288,41 @@ def test_intersection_time_2D(monkeypatch):
         channel_independent=False,
         plot=False)
     npt.assert_allclose(actual, expected)
+
+
+def test_energy_decay_curve_threshold():
+
+    t_60 = 1
+    m = -60/t_60
+
+    n_samples = 10
+    times = np.linspace(0, 1, n_samples)
+    edc_log = np.atleast_2d(times * m)
+
+    edc_log = np.tile(edc_log, (2, 3, 1))
+
+    edc = enh._truncate_energy_decay_curve(10**(edc_log.copy()/10), 30)
+
+    edc_ref = 10**(edc_log.copy()/10)
+    edc_ref[..., n_samples//2:] = np.nan
+
+    npt.assert_allclose(edc, edc_ref)
+
+
+def test_truncate_energy_decay_curve():
+    t_60 = 1
+    m = -60/t_60
+
+    n_samples = 10
+    times = np.linspace(0, 1, n_samples)
+    edc_log = np.atleast_2d(times * m)
+
+    edc_log = np.tile(edc_log, (2, 3, 1))
+
+    edc = pf.TimeData(10**(edc_log.copy()/10), times)
+    edc_trunc = enh.truncate_energy_decay_curve(edc, 30)
+
+    edc_ref = 10**(edc_log.copy()/10)
+    edc_ref[..., n_samples//2:] = np.nan
+
+    npt.assert_allclose(edc_trunc.time, edc_ref)


### PR DESCRIPTION
Add a threshold option to discard parts of the EDC affected by truncation or noise artifacts.
For truncated integration this is in line with ISO 354:2009-1, which specifies a valid range for RT estimation from EDCs calculated as the $D = (PSNR - T)$, and $T = 15~\mathrm{dB}$

New function defaults are truncation to a threshold of
- 15 dB for truncated integration `energy_decay_curve_truncation`
- 10 dB for noise subtraction before integration `energy_decay_curve_chu`

This PR also implements
- `peak_signal_to_noise_ratio` to estimate the PSNR for impulse responses
- `truncate_energy_decay_curve` to truncate energy decay curves.